### PR TITLE
tippy.js override

### DIFF
--- a/overrides.json
+++ b/overrides.json
@@ -625,5 +625,21 @@
         "./dist/commonjs/addons/Confirm": "./dist/commonjs/addons/Confirm/index.js"
       }
     }
+  },
+  "tippy.js": {
+    "6": {
+      "exports": {
+        ".": {
+          "module": "./dist/tippy.esm.js",
+          "default": "./dist/tippy.cjs.js"
+        },
+        "./headless": {
+          "module": "./headless/dist/tippy-headless.esm.js",
+          "default": "./headless/dist/tippy-headless.cjs.js"
+        },
+        "./headless/dist/tippy-headless.cjs.js": "./headless/dist/tippy-headless.cjs.js",
+        "./headless/dist/tippy-headless.esm.js": "./headless/dist/tippy-headless.esm.js"
+      }
+    }
   }
 }


### PR DESCRIPTION
This creates an override for tippy.js 6 to ensure the headless module is exported.

//cc @giltayar