### PR TITLE
Adds @vue/reactivity and @vue/shared ESM browser modules

### DIFF
--- a/overrides.json
+++ b/overrides.json
@@ -1243,18 +1243,16 @@
   "@vue/reactivity": {
     "3": {
       "exports": {
-        ".": {
-          "module": "./dist/reactivity.esm-browser.js"
-        }
+        "module": "./dist/reactivity.esm-browser.js",
+        "default": "./index.js"
       }
     }
   },
   "@vue/shared": {
     "3": {
       "exports": {
-        ".": {
-          "module": "./dist/shared.esm-browser.js"
-        }
+        "module": "./dist/shared.esm-browser.js",
+        "default": "./index.js"
       }
     }
   }

--- a/overrides.json
+++ b/overrides.json
@@ -1239,5 +1239,23 @@
         "./dist/mini.umd.js": "./dist/mini.umd.js"
       }
     }
+  },
+  "@vue/reactivity": {
+    "3": {
+      "exports": {
+        ".": {
+          "module": "./dist/reactivity.esm-browser.js"
+        }
+      }
+    }
+  },
+  "@vue/shared": {
+    "3": {
+      "exports": {
+        ".": {
+          "module": "./dist/shared.esm-browser.js"
+        }
+      }
+    }
   }
 }

--- a/overrides.json
+++ b/overrides.json
@@ -1250,10 +1250,7 @@
   },
   "@vue/shared": {
     "3": {
-      "exports": {
-        "module": "./dist/shared.esm-browser.js",
-        "default": "./index.js"
-      }
+      "exports": "./index.js",
     }
   }
 }

--- a/overrides.json
+++ b/overrides.json
@@ -1252,5 +1252,11 @@
     "3": {
       "exports": "./index.js",
     }
+  },
+  "@vue/runtime-dom": {
+    "3": {
+      "module": "./dist/runtime-dom.esm-browser.js",
+      "default": "./index.js"
+    }
   }
 }


### PR DESCRIPTION
### Added

- Overrides the module exports of `@vue/reactivity` and `@vue/shared` to the correct ESM exports (browser-ready instead of bundle version).

---

Since these are kind of "internal" packages for Vue, not sure if it makes sense for them to export the ESM browser modules instead of the bundle ones by default.

I noticed this only because as of version 3.12.1 of Alpine.js, it started listing these packages as scoped dependencies. Which makes it so that using Alpine with import maps only (no bundling) breaks (because there's no global process).

- Here's the JSPM Generator link showing the issue: https://generator.jspm.io/#U2NiYGBkDM0rySzJSU1hSMwpyMxLzSp2MNYzNNIzBAD+yFbRHgA
- Here's the original Alpine.js discussion: https://github.com/alpinejs/alpine/discussions/3573#discussioncomment-5897448