### PR TITLE
Add overrides for vue3 browser bundle

### DIFF
--- a/overrides.json
+++ b/overrides.json
@@ -1323,5 +1323,11 @@
       "module": "./dist/runtime-dom.esm-browser.js",
       "default": "./index.js"
     }
+  },
+  "vue": {
+    "3": {
+        "module": "./dist/vue.esm-browser.js",
+        "default": "./index.js"
+    }
   }
 }


### PR DESCRIPTION
Contributing regarding issue https://github.com/jspm/generator/issues/325

I wonder If we could add the prod build as well, since `vue.esm-browser.js` is a dev build and `vue.esm-browser.prod.js` is the proper prod build.