### PR TITLE
feat: add overrides for Material UI 5

### DIFF
--- a/overrides.json
+++ b/overrides.json
@@ -678,7 +678,102 @@
       }
     }
   },
+  "@mui/icons-material": {
+    "5": {
+      "exports": {
+        ".": {
+          "module": "./esm/index.js",
+          "import": "./esm/index.js",
+          "require": "./index.js"
+        },
+        "./index.js": "./index.js",
+        "./index": null,
+        "./*": {
+          "module": "./esm/*.js",
+          "import": "./esm/*.js",
+          "require": "./*.js"
+        },
+        "./esm/*": "./esm/*.js"
+      }
+    }
+  },
+  "@mui/core": {
+    "5": {
+      "exports": {
+        ".": {
+          "module": "./esm/index.js",
+          "import": "./esm/index.js",
+          "require": "./index.js"
+        },
+        "./index.js": "./index.js",
+        "./index": null,
+        "./*": {
+          "module": "./esm/*.js",
+          "import": "./esm/*.js",
+          "require": "./*.js"
+        },
+        "./esm/*": "./esm/*.js"
+      }
+    }
+  },
+  "@mui/lab": {
+    "5": {
+      "exports": {
+        ".": {
+          "module": "./esm/index.js",
+          "import": "./esm/index.js",
+          "require": "./index.js"
+        },
+        "./index.js": "./index.js",
+        "./index": null,
+        "./*": {
+          "module": "./esm/*.js",
+          "import": "./esm/*.js",
+          "require": "./*.js"
+        },
+        "./esm/*": "./esm/*.js"
+      }
+    }
+  },
+  "@mui/styles": {
+    "5": {
+      "exports": {
+        ".": {
+          "module": "./esm/index.js",
+          "import": "./esm/index.js",
+          "require": "./index.js"
+        },
+        "./index.js": "./index.js",
+        "./index": null,
+        "./*": {
+          "module": "./esm/*.js",
+          "import": "./esm/*.js",
+          "require": "./*.js"
+        },
+        "./esm/*": "./esm/*.js"
+      }
+    }
+  },
   "@mui/system": {
+    "5": {
+      "exports": {
+        ".": {
+          "module": "./esm/index.js",
+          "import": "./esm/index.js",
+          "require": "./index.js"
+        },
+        "./index.js": "./index.js",
+        "./index": null,
+        "./*": {
+          "module": "./esm/*.js",
+          "import": "./esm/*.js",
+          "require": "./*.js"
+        },
+        "./esm/*": "./esm/*.js"
+      }
+    }
+  },
+  "@mui/utils": {
     "5": {
       "exports": {
         ".": {


### PR DESCRIPTION
Added support for Material UI 5 (duplicating the existing infrastructure for changed package names).