### PR TITLE
Overrides for @wordpress/commands@1.29.0 & @wordpress/core-data@7.29.0

### DIFF
--- a/overrides.json
+++ b/overrides.json
@@ -1566,5 +1566,29 @@
         "./build-module/index.js": "./build-module/index.js"
       }
     }
+  },
+  "@wordpress/commands": {
+    "1": {
+      "exports": {
+        ".": {
+          "module": "./build-module/index.js",
+          "default": "./build/index.js"
+        },
+        "./build/index.js": "./build/index.js",
+        "./build-module/index.js": "./build-module/index.js"
+      }
+    }
+  },
+  "@wordpress/core-data": {
+    "7": {
+      "exports": {
+        ".": {
+          "module": "./build-module/index.js",
+          "default": "./build/index.js"
+        },
+        "./build/index.js": "./build/index.js",
+        "./build-module/index.js": "./build-module/index.js"
+      }
+    }
   }
 }

--- a/overrides.json
+++ b/overrides.json
@@ -1509,10 +1509,54 @@
         "./build/index.js": "./build/index.js",
         "./build-module/index.js": "./build-module/index.js"
       }
+    },
+    "10": {
+      "exports": {
+        ".": {
+          "module": "./build-module/index.js",
+          "default": "./build/index.js"
+        },
+        "./build/index.js": "./build/index.js",
+        "./build-module/index.js": "./build-module/index.js"
+      }
     }
   },
   "@wordpress/primitives": {
+    "3": {
+      "exports": {
+        ".": {
+          "module": "./build-module/index.js",
+          "default": "./build/index.js"
+        },
+        "./build/index.js": "./build/index.js",
+        "./build-module/index.js": "./build-module/index.js"
+      }
+    },
     "4": {
+      "exports": {
+        ".": {
+          "module": "./build-module/index.js",
+          "default": "./build/index.js"
+        },
+        "./build/index.js": "./build/index.js",
+        "./build-module/index.js": "./build-module/index.js"
+      }
+    }
+  },
+  "@wordpress/compose": {
+    "6": {
+      "exports": {
+        ".": {
+          "module": "./build-module/index.js",
+          "default": "./build/index.js"
+        },
+        "./build/index.js": "./build/index.js",
+        "./build-module/index.js": "./build-module/index.js"
+      }
+    }
+  },
+  "@wordpress/icons": {
+    "9": {
       "exports": {
         ".": {
           "module": "./build-module/index.js",


### PR DESCRIPTION
Thank you! Please trigger rebuilds for the following packages:
- @wordpress/commands@1.29.0
- @wordpress/core-data@7.29.0