### PR TITLE
Add `package json`

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,0 +1,6 @@
+{                                                                                                                                                                                       
+  "name": "@jspm/overrides",                                                                                                                                                            
+  "version": "1.0.0",                                                                                                                                                                   
+  "exports": "./overrides.json",                                                                                                                                                        
+  "type": "module"                                                                                                                                                                      
+} 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
-{                                                                                                                                                                                       
-  "name": "@jspm/overrides",                                                                                                                                                            
-  "version": "1.0.0",                                                                                                                                                                   
-  "exports": "./overrides.json",                                                                                                                                                        
-  "type": "module"                                                                                                                                                                      
-} 
+{
+  "name": "@jspm/overrides",
+  "version": "1.0.0",
+  "exports": "./overrides.json",
+  "type": "module"
+}


### PR DESCRIPTION
Currently, this cannot be installed via npm even as a repo dependency. Adding a `package.json` fixes that. I kept it minimal, but happy to make any edits you want!

Note that #28 also includes this change.