### PR TITLE
Fix Vue override to use full build instead of runtime-only

### DIFF
--- a/overrides.json
+++ b/overrides.json
@@ -648,7 +648,8 @@
   "@vue/shared": {
     "3": {
       "exports": "./index.js"
-    }
+    },
+    "3.5": null
   },
   "elliptic": {
     "6": {

--- a/overrides.json
+++ b/overrides.json
@@ -1448,8 +1448,8 @@
             "types": "./dist/vue.d.mts",
             "node": "./index.mjs",
             "browser": {
-              "development": "./dist/vue.runtime.esm-browser.js",
-              "default": "./dist/vue.runtime.esm-browser.prod.js"
+              "development": "./dist/vue.esm-browser.js",
+              "default": "./dist/vue.esm-browser.prod.js"
             },
             "default": "./dist/vue.runtime.esm-bundler.js"
           },


### PR DESCRIPTION
Fixes #29

I also fixed the `@vue/shared` override for 3.5+ by replacing it with `null` (not sure if that's the right convention for "no override"?).
Vue 3.5+ added proper exports with module/import conditions, so the
override was overwriting good metadata and resolving to CJS.